### PR TITLE
Added hpHosts feeds support

### DIFF
--- a/core/conf/feeds/bambenek_c2cDOMAIN.conf
+++ b/core/conf/feeds/bambenek_c2cDOMAIN.conf
@@ -1,0 +1,47 @@
+
+[source]
+url=http://osint.bambenekconsulting.com/feeds/c2-dommasterlist.txt
+delimiter : ,
+beginWithBlank : False
+fields : ["domain", "used_by", "submission_datetime", "reference_url"]
+extraFields : 
+description : Master Feed of known, active and non-sinkholed C&Cs domain names 
+startAt : 1
+score : -100
+coreIntelligence : domain
+validityDate:
+useByDate:
+
+[elasticsearch]
+typeIntel= bambeneck_c2cDOMAIN
+
+[intel]
+domain = {
+	"mapping" : {
+		"type": "string",
+		"index": "not_analyzed"
+		}
+	}
+
+used_by = {
+	"mapping" : {
+		"type": "string",
+		"index": "not_analyzed"
+		}
+	}
+
+submission_datetime = {
+	"mapping" : {
+		"type": "date",
+		"format" : "yyyy-MM-dd HH:mm",
+		"index": "no"
+		}
+	}
+
+reference_url = {
+	"mapping" : {
+		"type": "string",
+		"index": "no"
+		}
+	}
+

--- a/core/conf/feeds/bambenek_c2cIP.conf
+++ b/core/conf/feeds/bambenek_c2cIP.conf
@@ -1,0 +1,47 @@
+
+[source]
+url=http://osint.bambenekconsulting.com/feeds/c2-ipmasterlist.txt
+delimiter : ,
+beginWithBlank : False
+fields : ["ip", "used_by", "submission_datetime", "reference_url"]
+extraFields : 
+description : Master Feed of known, active and non-sinkholed C&Cs IP addresses
+startAt : 1
+score : -100
+coreIntelligence : ip
+validityDate:
+useByDate:
+
+[elasticsearch]
+typeIntel= bambeneck_c2cIP
+
+[intel]
+ip = {
+	"mapping" : {
+		"type": "ip",
+		"index": "not_analyzed"
+		}
+	}
+
+used_by = {
+	"mapping" : {
+		"type": "string",
+		"index": "not_analyzed"
+		}
+	}
+
+submission_datetime = {
+	"mapping" : {
+		"type": "date",
+		"format" : "yyyy-MM-dd HH:mm",
+		"index": "no"
+		}
+	}
+
+reference_url = {
+	"mapping" : {
+		"type": "string",
+		"index": "no"
+		}
+	}
+

--- a/core/conf/feeds/bambenek_dgaDOMAIN.conf
+++ b/core/conf/feeds/bambenek_dgaDOMAIN.conf
@@ -1,0 +1,47 @@
+
+[source]
+url=http://osint.bambenekconsulting.com/feeds/dga-feed.txt
+delimiter : ,
+beginWithBlank : False
+fields : ["domain", "used_by", "submission_datetime", "reference_url"]
+extraFields : 
+description : Domain feed of known DGA domains from -2 to +3 days 
+startAt : 1
+score : -100
+coreIntelligence : domain
+validityDate:
+useByDate:
+
+[elasticsearch]
+typeIntel= bambeneck_c2cDOMAIN
+
+[intel]
+domain = {
+	"mapping" : {
+		"type": "string",
+		"index": "not_analyzed"
+		}
+	}
+
+used_by = {
+	"mapping" : {
+		"type": "string",
+		"index": "not_analyzed"
+		}
+	}
+
+submission_datetime = {
+	"mapping" : {
+		"type": "date",
+		"format" : "yyyy-MM-dd HH:mm",
+		"index": "no"
+		}
+	}
+
+reference_url = {
+	"mapping" : {
+		"type": "string",
+		"index": "no"
+		}
+	}
+

--- a/core/conf/feeds/hpHosts_emdDOMAIN.conf
+++ b/core/conf/feeds/hpHosts_emdDOMAIN.conf
@@ -1,0 +1,30 @@
+
+[source]
+url=https://hosts-file.net/emd.txt
+delimiter : \t
+beginWithBlank : False
+fields : ["localhost", "domain"]
+extraFields : 
+description : This file contains malware sites listed in the hpHosts database. This should ONLY be downloaded by those wanting to block malware sites and nothing else, and requires manual merging.  
+startAt : 7
+score : -100
+coreIntelligence : domain 
+validityDate:
+useByDate:
+
+[elasticsearch]
+typeIntel = host_file_emdDOMAIN
+
+[intel]
+localhost = {
+	"mapping" : {
+		"type": "string",
+		"index": "no"
+		}
+	}
+domain = {
+	"mapping" : {
+		"type": "string",
+		"index": "not_analyzed"
+		}
+	}

--- a/core/conf/feeds/hpHosts_expDOMAIN.conf
+++ b/core/conf/feeds/hpHosts_expDOMAIN.conf
@@ -1,0 +1,30 @@
+
+[source]
+url=https://hosts-file.net/exp.txt
+delimiter : \t
+beginWithBlank : False
+fields : ["localhost", "domain"]
+extraFields : 
+description : This file contains exploit sites listed in the hpHosts database. This should ONLY be downloaded by those wanting to block exploit sites and nothing else, and requires manual merging.  
+startAt : 7
+score : -100
+coreIntelligence : domain 
+validityDate:
+useByDate:
+
+[elasticsearch]
+typeIntel = host_file_expDOMAIN
+
+[intel]
+localhost = {
+	"mapping" : {
+		"type": "string",
+		"index": "no"
+		}
+	}
+domain = {
+	"mapping" : {
+		"type": "string",
+		"index": "not_analyzed"
+		}
+	}

--- a/core/conf/feeds/hpHosts_fsaDOMAIN.conf
+++ b/core/conf/feeds/hpHosts_fsaDOMAIN.conf
@@ -1,0 +1,30 @@
+
+[source]
+url=https://hosts-file.net/fsa.txt
+delimiter : \t
+beginWithBlank : False
+fields : ["localhost", "domain"]
+extraFields : 
+description : This file contains fraud sites listed in the hpHosts database. This should ONLY be downloaded by those wanting to block fraud sites and nothing else, and requires manual merging.  
+startAt : 7
+score : -100
+coreIntelligence : domain 
+validityDate:
+useByDate:
+
+[elasticsearch]
+typeIntel = host_file_fsaDOMAIN
+
+[intel]
+localhost = {
+	"mapping" : {
+		"type": "string",
+		"index": "no"
+		}
+	}
+domain = {
+	"mapping" : {
+		"type": "string",
+		"index": "not_analyzed"
+		}
+	}

--- a/core/conf/feeds/hpHosts_grmDOMAIN.conf
+++ b/core/conf/feeds/hpHosts_grmDOMAIN.conf
@@ -1,0 +1,30 @@
+
+[source]
+url=https://hosts-file.net/grm.txt
+delimiter : \t
+beginWithBlank : False
+fields : ["localhost", "domain"]
+extraFields : 
+description : This file contains sites involved in spam (that do not otherwise meet any other classification criteria) listed in the hpHosts database This should ONLY be downloaded by those wanting to block spam sites and nothing else, and requires manual merging.
+startAt : 7
+score : -100
+coreIntelligence : domain 
+validityDate:
+useByDate:
+
+[elasticsearch]
+typeIntel = host_file_grmDOMAIN
+
+[intel]
+localhost = {
+	"mapping" : {
+		"type": "string",
+		"index": "no"
+		}
+	}
+domain = {
+	"mapping" : {
+		"type": "string",
+		"index": "not_analyzed"
+		}
+	}

--- a/core/conf/feeds/hpHosts_hjkDOMAIN.conf
+++ b/core/conf/feeds/hpHosts_hjkDOMAIN.conf
@@ -1,0 +1,30 @@
+
+[source]
+url=https://hosts-file.net/hjk.txt
+delimiter : \t
+beginWithBlank : False
+fields : ["localhost", "domain"]
+extraFields : 
+description : This file contains hijack sites listed in the hpHosts database This should ONLY be downloaded by those wanting to block hijack sites and nothing else, and requires manual merging.
+startAt : 7
+score : -100
+coreIntelligence : domain 
+validityDate:
+useByDate:
+
+[elasticsearch]
+typeIntel = host_file_hjkDOMAIN
+
+[intel]
+localhost = {
+	"mapping" : {
+		"type": "string",
+		"index": "no"
+		}
+	}
+domain = {
+	"mapping" : {
+		"type": "string",
+		"index": "not_analyzed"
+		}
+	}

--- a/core/conf/feeds/hpHosts_pshDOMAIN.conf
+++ b/core/conf/feeds/hpHosts_pshDOMAIN.conf
@@ -1,0 +1,30 @@
+
+[source]
+url=https://hosts-file.net/psh.txt
+delimiter : \t
+beginWithBlank : False
+fields : ["localhost", "domain"]
+extraFields : 
+description : This file contains phishing sites listed in the hpHosts database This should ONLY be downloaded by those wanting to block phishing sites and nothing else, and requires manual merging.  
+startAt : 7
+score : -100
+coreIntelligence : domain 
+validityDate:
+useByDate:
+
+[elasticsearch]
+typeIntel = host_file_pshDOMAIN
+
+[intel]
+localhost = {
+	"mapping" : {
+		"type": "string",
+		"index": "no"
+		}
+	}
+domain = {
+	"mapping" : {
+		"type": "string",
+		"index": "not_analyzed"
+		}
+	}

--- a/core/conf/feeds/hpHosts_pupDOMAIN.conf
+++ b/core/conf/feeds/hpHosts_pupDOMAIN.conf
@@ -1,0 +1,30 @@
+
+[source]
+url=https://hosts-file.net/pup.txt
+delimiter : \t
+beginWithBlank : False
+fields : ["localhost", "domain"]
+extraFields : 
+description : This file contains PUP sites listed in the hpHosts database This should ONLY be downloaded by those wanting to block PUP (Potentially Unwanted Programs) sites and nothing else, and requires manual merging. 
+startAt : 7
+score : -100
+coreIntelligence : domain 
+validityDate:
+useByDate:
+
+[elasticsearch]
+typeIntel = host_file_pupDOMAIN
+
+[intel]
+localhost = {
+	"mapping" : {
+		"type": "string",
+		"index": "no"
+		}
+	}
+domain = {
+	"mapping" : {
+		"type": "string",
+		"index": "not_analyzed"
+		}
+	}

--- a/core/conf/feeds/hpHosts_wrzDOMAIN.conf
+++ b/core/conf/feeds/hpHosts_wrzDOMAIN.conf
@@ -1,0 +1,30 @@
+
+[source]
+url=https://hosts-file.net/wrz.txt
+delimiter : \t
+beginWithBlank : False
+fields : ["localhost", "domain"]
+extraFields : 
+description : This file contains warez/piracy sites listed in the hpHosts database This should ONLY be downloaded by those wanting to block warez/piracy sites and nothing else, and requires manual merging. 
+startAt : 7
+score : -100
+coreIntelligence : domain 
+validityDate:
+useByDate:
+
+[elasticsearch]
+typeIntel = host_file_wrzDOMAIN
+
+[intel]
+localhost = {
+	"mapping" : {
+		"type": "string",
+		"index": "no"
+		}
+	}
+domain = {
+	"mapping" : {
+		"type": "string",
+		"index": "not_analyzed"
+		}
+	}


### PR DESCRIPTION
hpHosts is a community managed and maintained hosts file that allows an additional layer of protection against access to ad, tracking and malicious websites.