### PR TITLE
Added check to prevent 500 error

### DIFF
--- a/core/services/hipposcore.py
+++ b/core/services/hipposcore.py
@@ -42,6 +42,10 @@ def calcHipposcore(dictResult):
 				for match in listMatches:
 					#n1 retrieving the source according to its id
 					idSource = match['idSource']
+					if idSource = None:
+						logger.critical('hipposcore.calcHipposcore.idSource is type None')
+						logger.info(match)
+						continue
 					n1 = cache.get(idSource)
 					if n1 is None:
 						source = ExistingSource(idSource)


### PR DESCRIPTION
If, for some reason an idSource is not created, Hippocampe will return a 500 error. This will prevent this